### PR TITLE
Fix urlencoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog (aws-requests-auth)
 ==================
 
+0.2.1
+------------------
+- Fix bug where cannonical uri was not url encoded appropriately for the signing process
+
+
 0.2.0
 ------------------
 - Fix typos of `aws_secret_access_key` : https://github.com/DavidMuller/aws-requests-auth/pull/1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog (aws-requests-auth)
 
 0.2.1
 ------------------
-- Fix bug where cannonical uri was not url encoded appropriately for the signing process
+- Fix bug where cannonical uri and query string was not url encoded appropriately for the signing process
 
 
 0.2.0

--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -1,4 +1,5 @@
 import hmac
+import urllib
 import hashlib
 import datetime
 from urlparse import urlparse
@@ -74,7 +75,8 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         # Create the canonical query string. In this example (a GET request),
         # request parameters are in the query string. Query string values must
         # be URL-encoded (space=%20). The parameters must be sorted by name.
-        canonical_querystring = '&'.join(sorted(parsedurl.query.split('&')))
+        querystring_sorted = '&'.join(sorted(parsedurl.query.split('&')))
+        canonical_querystring = urllib.quote_plus(querystring_sorted)
 
         # Create the canonical headers and signed headers. Header names
         # and value must be trimmed and lowercase, and sorted in ASCII order.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='aws-requests-auth',
-    version='0.2.0',
+    version='0.2.1',
     author='David Muller',
     author_email='davehmuller@gmail.com',
     packages=['aws_requests_auth'],


### PR DESCRIPTION
why
---
some basic requests to elastic search clusters were failing to be signed correctly

what
---
in the signing process canonical uri and query string are url escaped.
bumps version and updates change log