### PR TITLE
Don't quote query string param value, it's already been quoted.

### DIFF
--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -166,9 +166,9 @@ class AWSRequestsAuth(requests.auth.AuthBase):
             # safe chars adopted from boto source
             # https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/auth.py#L359-L360
             key = urllib.quote(key_val_split[0], safe='-_.~')
-            try:
-                val = urllib.quote(key_val_split[1], safe='-_.~')
-            except IndexError:
+            if len(key_val_split) > 1:
+                val = key_val_split[1]
+            else:
                 val = ''
 
             if key:


### PR DESCRIPTION
I've been successfully using this library to sign requests for my AWS hosted Elasticsearch service.  But today I wanted to use the ``reindex`` functionality available in ``helpers`` and I ran into an issue.  I would get this error:

```
AuthorizationException: TransportError(403, u'{"message":"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.\\n\\nThe Canonical String for this request should have been\\n\'GET\\n/bedd088a-7e6b-44a6-b221-0b07dd1bb00a/_search\\nfields=_source%2C_parent%2C_routing%2C_timestamp&scroll=5m&search_type=scan\\nhost:search-foobar.us-west-2.es.amazonaws.com\\nx-amz-date:20160222T164801Z\\n\\nhost;x-amz-date\\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\'\\n\\nThe String-to-Sign should have been\\n\'AWS4-HMAC-SHA256\\n20160222T164801Z\\n20160222/us-west-2/es/aws4_request\\nb8bcbada74ff95cb691b25561c00acc41515f8c2d47f73be6b3d91ff99ce17cb\'\\n"}')
```

I put some debug printing in and found that the actual canonical string being calculated by the library was:

```
==== canonical request ====
GET
/bedd088a-7e6b-44a6-b221-0b07dd1bb00a/_search
fields=_source%252C_parent%252C_routing%252C_timestamp&scroll=5m&search_type=scan
host:search-foobar.us-west-2.es.amazonaws.com
x-amz-date:20160222T164801Z
```

So it appears that the value part of the ``fields`` query parameter has been quoted twice.  I changed this code (as per this PR) and the ``reindex`` operation worked just fine.

If you look at the value of ``querystring_sorted`` in ``get_canonical_querystring`` it looks like this:

```
==== querystring_sorted ====
fields=_source%2C_parent%2C_routing%2C_timestamp&scroll=5m&search_type=scan
key_val_split
['fields', '_source%2C_parent%2C_routing%2C_timestamp']
key_val_split
['scroll', '5m']
key_val_split
['search_type', 'scan']
```

And you can see that the values are already quoted by requests.