### PR TITLE
[cosmetic] fix 'canonical' mispelled as 'caononical'

### DIFF
--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -72,7 +72,7 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time for credential_scope
 
-        canonical_uri = AWSRequestsAuth.get_caononical_path(r)
+        canonical_uri = AWSRequestsAuth.get_canonical_path(r)
 
         canonical_querystring = AWSRequestsAuth.get_canonical_querystring(r)
 
@@ -137,7 +137,7 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         return r
 
     @classmethod
-    def get_caononical_path(cls, r):
+    def get_canonical_path(cls, r):
         """
         Create canonical URI--the part of the URI from domain to query
         string (use '/' if no path)

--- a/aws_requests_auth/tests/test_aws_auth.py
+++ b/aws_requests_auth/tests/test_aws_auth.py
@@ -20,7 +20,7 @@ class TestAWSRequestsAuth(unittest.TestCase):
         url = 'http://search-foo.us-east-1.es.amazonaws.com:80/'
         mock_request = mock.Mock()
         mock_request.url = url
-        self.assertEqual('/', AWSRequestsAuth.get_caononical_path(mock_request))
+        self.assertEqual('/', AWSRequestsAuth.get_canonical_path(mock_request))
         self.assertEqual('', AWSRequestsAuth.get_canonical_querystring(mock_request))
 
     def test_characters_escaped_in_path(self):
@@ -31,7 +31,7 @@ class TestAWSRequestsAuth(unittest.TestCase):
         url = 'http://search-foo.us-east-1.es.amazonaws.com:80/+foo.*/_stats'
         mock_request = mock.Mock()
         mock_request.url = url
-        self.assertEqual('/%2Bfoo.%2A/_stats', AWSRequestsAuth.get_caononical_path(mock_request))
+        self.assertEqual('/%2Bfoo.%2A/_stats', AWSRequestsAuth.get_canonical_path(mock_request))
         self.assertEqual('', AWSRequestsAuth.get_canonical_querystring(mock_request))
 
     def test_path_with_querystring(self):
@@ -42,7 +42,7 @@ class TestAWSRequestsAuth(unittest.TestCase):
         url = 'http://search-foo.us-east-1.es.amazonaws.com:80/my_index/?pretty=True'
         mock_request = mock.Mock()
         mock_request.url = url
-        self.assertEqual('/my_index/', AWSRequestsAuth.get_caononical_path(mock_request))
+        self.assertEqual('/my_index/', AWSRequestsAuth.get_canonical_path(mock_request))
         self.assertEqual('pretty=True', AWSRequestsAuth.get_canonical_querystring(mock_request))
 
     def test_multiple_get_params(self):


### PR DESCRIPTION
This fixes a purely cosmetic typo in the "get_canonical_path" method's name.