### PR TITLE
encode body before hashing, for python 3.6

### DIFF
--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -101,7 +101,7 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').
         body = r.body if r.body else bytes()
-        payload_hash = hashlib.sha256(body).hexdigest()
+        payload_hash = hashlib.sha256(body.encode('utf-8')).hexdigest()
 
         # Combine elements to create create canonical request
         canonical_request = (r.method + '\n' + canonical_uri + '\n' +


### PR DESCRIPTION
encoding needs to take place before hashing, required to make this work for python 3.6 