### PR TITLE
adds try-based utf-8 body encoding for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.6"
   
 # command to install dependencies
 install: pip install -r requirements.txt

--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -100,7 +100,6 @@ class AWSRequestsAuth(requests.auth.AuthBase):
 
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').
-        #body = r.body if r.body else bytes()
         body = r.body if r.body else bytes()
         try:
             body = body.encode('utf-8')

--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -100,7 +100,12 @@ class AWSRequestsAuth(requests.auth.AuthBase):
 
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').
+        #body = r.body if r.body else bytes()
         body = r.body if r.body else bytes()
+        try:
+            body = body.encode('utf-8')
+        except AttributeError:
+            body = body
         payload_hash = hashlib.sha256(body).hexdigest()
 
         # Combine elements to create create canonical request

--- a/aws_requests_auth/tests/test_aws_auth.py
+++ b/aws_requests_auth/tests/test_aws_auth.py
@@ -119,3 +119,31 @@ class TestAWSRequestsAuth(unittest.TestCase):
             'x-amz-date': '20160618T220405Z',
 
         }, mock_request.headers)
+
+    def test_auth_for_post_with_str_body(self):
+        auth = AWSRequestsAuth(aws_access_key='YOURKEY',
+                               aws_secret_access_key='YOURSECRET',
+                               aws_host='search-foo.us-east-1.es.amazonaws.com',
+                               aws_region='us-east-1',
+                               aws_service='es')
+        url = 'http://search-foo.us-east-1.es.amazonaws.com:80/'
+        mock_request = mock.Mock()
+        mock_request.url = url
+        mock_request.method = "POST"
+        mock_request.body = 'foo=bar'
+        mock_request.headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+
+        frozen_datetime = datetime.datetime(2016, 6, 18, 22, 4, 5)
+        with mock.patch('datetime.datetime') as mock_datetime:
+            mock_datetime.utcnow.return_value = frozen_datetime
+            auth(mock_request)
+        self.assertEqual({
+            'Authorization': 'AWS4-HMAC-SHA256 Credential=YOURKEY/20160618/us-east-1/es/aws4_request, '
+                             'SignedHeaders=host;x-amz-date, '
+                             'Signature=a6fd88e5f5c43e005482894001d9b05b43f6710e96be6098bcfcfccdeb8ed812',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'x-amz-date': '20160618T220405Z',
+
+        }, mock_request.headers)


### PR DESCRIPTION
This adds an encoding to utf-8 for the body of a request, if present. Due to encoding differences between python 2 and 3, we can't just apply the encoding blindly.
Example: b'foo' is a str in python 2, and a bytes literal in python 3. 
b'foo'.encode('utf-8') works in python 2, since it's a string. The `b` is ignored. 
b'foo'.encode('utf-8') fails in python 3, since it's already a byte literal. 

Added a post test with a string literal body. 