### PR TITLE
add Python and Python3 classifiers to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,9 @@ setup(
     description='AWS signature version 4 signing process for the python requests module',
     long_description='See https://github.com/davidmuller/aws-requests-auth for installation and usage instructions.',
     install_requires=['requests>=0.14.0'],
+    classifiers=(
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        )
 )


### PR DESCRIPTION
This will let me use [brettcannon/caniusepython3](https://caniusepython3.com/)
and will show this package supports Python3 on PyPI.

(Needs to be rebuild and pushed to PyPI to take effect)