### PR TITLE
support gathering refreshed credentials from underlying boto Session at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,24 +91,23 @@ def lambda_handler(event, context):
 ```
 `'AWS_ACCESS_KEY_ID'`, `'AWS_SECRET_ACCESS_KEY'`, `'AWS_SESSION_TOKEN'` are [reserved environment variables in AWS lambdas](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html#lambda-environment-variables).
 
-## Using boto3 To Automatically Gather AWS Credentials
-`boto3` is not a strict requirement of `aws-requests-auth`, but we do provide some convenience methods if you'd like to use `boto3` to automatically retrieve your AWS credentials for you.
+## Using Boto To Automatically Gather AWS Credentials
+`botocore` (the core functionality of `boto3`) is not a strict requirement of `aws-requests-auth`, but we do provide some convenience methods if you'd like to use `botocore` to automatically retrieve your AWS credentials for you.
 
-`boto3` [can dynamically pull AWS credentials from environment variables, AWS config files, IAM Role,
+`botocore` [can dynamically pull AWS credentials from environment variables, AWS config files, IAM Role,
 and other locations](http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials). Dynamic credential fetching can come in handy if you need to run a program leveraging `aws-requests-auth` in several places where you may authenticate in different manners. For example, you may rely on a `.aws/credentials` file when running on your local machine, but use an IAM role when running your program in a docker container in the cloud.
 
-To take advantage of these conveniences, and help you authenticate wherever `boto3` finds AWS credentials, you can import the `boto_utils` file and initialize `AWSRequestsAuth` as follows:
+To take advantage of these conveniences, and help you authenticate wherever `botocore` finds AWS credentials, you can import the `boto_utils` file and initialize `BotoAWSRequestsAuth` as follows:
 
 ```python
-from aws_requests_auth.aws_auth import AWSRequestsAuth
-
-# note that this line will fail if you do not have boto3 installed
-# boto3 installation instructions available here:
+# note that this line will fail if you do not have botocore installed
+# botocore installation instructions available here:
 # https://boto3.readthedocs.io/en/latest/guide/quickstart.html#installation
-from aws_requests_auth import boto_utils
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
-auth = AWSRequestsAuth(aws_host='search-service-foobar.us-east-1.es.amazonaws.com',
+auth = BotoAWSRequestsAuth(aws_host='search-service-foobar.us-east-1.es.amazonaws.com',
                        aws_region='us-east-1',
-                       aws_service='es',
-                       **boto_utils.get_credentials())
+                       aws_service='es')
 ```
+
+Credentials are only accessed when needed at runtime, and they will be refreshed using the underlying methods in `botocore` if needed.

--- a/aws_requests_auth/boto_utils.py
+++ b/aws_requests_auth/boto_utils.py
@@ -4,20 +4,50 @@ External libraries, like boto, that this file imports are not a strict requireme
 aws-requests-auth package.
 """
 
-import boto3
+from botocore.session import Session
+
+from .aws_auth import AWSRequestsAuth
 
 
-def get_credentials():
+def get_credentials(credentials_obj=None):
     """
     Interacts with boto to retrieve AWS credentials, and returns a dictionary of
-    kwargs to be used in AWSRequestsAuth. boto automatically pulls AWS credentials from 
+    kwargs to be used in AWSRequestsAuth. boto automatically pulls AWS credentials from
     a variety of sources including but not limited to credentials files and IAM role.
-    AWS credentials are pulled in the order listed here: 
+    AWS credentials are pulled in the order listed here:
     http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
     """
-    credentials_obj = boto3.Session().get_credentials()
+    if credentials_obj is None:
+        credentials_obj = Session().get_credentials()
+    # use get_frozen_credentials to avoid the race condition where one or more
+    # properties may be refreshed and the other(s) not refreshed
+    frozen_credentials = credentials_obj.get_frozen_credentials()
     return {
-        'aws_access_key': credentials_obj.access_key,
-        'aws_secret_access_key': credentials_obj.secret_key,
-        'aws_token': credentials_obj.token,
+        'aws_access_key': frozen_credentials.access_key,
+        'aws_secret_access_key': frozen_credentials.secret_key,
+        'aws_token': frozen_credentials.token,
     }
+
+
+class BotoAWSRequestsAuth(AWSRequestsAuth):
+
+    def __init__(self, aws_host, aws_region, aws_service):
+        """
+        Example usage for talking to an AWS Elasticsearch Service:
+
+        BotoAWSRequestsAuth(aws_host='search-service-foobar.us-east-1.es.amazonaws.com',
+                            aws_region='us-east-1',
+                            aws_service='es')
+
+        The aws_access_key, aws_secret_access_key, and aws_token are discovered
+        automatically from the environment, in the order described here:
+        http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
+        """
+        super().__init__(None, None, aws_host, aws_region, aws_service)
+        self._refreshable_credentials = Session().get_credentials()
+
+    def __call__(self, r):
+        # update credentials immediately before each call in case they expired
+        for k, v in get_credentials(self._refreshable_credentials).items():
+            setattr(self, k, v)
+        return super().__call__(r)

--- a/aws_requests_auth/boto_utils.py
+++ b/aws_requests_auth/boto_utils.py
@@ -43,11 +43,11 @@ class BotoAWSRequestsAuth(AWSRequestsAuth):
         automatically from the environment, in the order described here:
         http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
         """
-        super().__init__(None, None, aws_host, aws_region, aws_service)
+        super(BotoAWSRequestsAuth, self).__init__(None, None, aws_host, aws_region, aws_service)
         self._refreshable_credentials = Session().get_credentials()
 
     def __call__(self, r):
         # update credentials immediately before each call in case they expired
         for k, v in get_credentials(self._refreshable_credentials).items():
             setattr(self, k, v)
-        return super().__call__(r)
+        return super(BotoAWSRequestsAuth, self).__call__(r)

--- a/aws_requests_auth/boto_utils.py
+++ b/aws_requests_auth/boto_utils.py
@@ -47,7 +47,7 @@ class BotoAWSRequestsAuth(AWSRequestsAuth):
         self._refreshable_credentials = Session().get_credentials()
 
     def __call__(self, r):
-        # update credentials immediately before each call in case they expired
-        for k, v in get_credentials(self._refreshable_credentials).items():
-            setattr(self, k, v)
-        return super(BotoAWSRequestsAuth, self).__call__(r)
+        # provide credentials explicitly for each __call__, to take advantage of botocore's
+        # underlying logic to refresh expired credentials
+        credentials = get_credentials(self._refreshable_credentials)
+        return super(BotoAWSRequestsAuth, self).__call__(r, **credentials)

--- a/aws_requests_auth/tests/test_boto_utils.py
+++ b/aws_requests_auth/tests/test_boto_utils.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+import mock
+
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth, get_credentials
+
+
+class TestBotoUtils(unittest.TestCase):
+    """
+    Tests for boto_utils module.
+    """
+
+    def setUp(self):
+        self.saved_env = {}
+        for var in ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']:
+            self.saved_env[var] = os.environ.get(var)
+            os.environ[var] = 'test-%s' % var
+
+    def tearDown(self):
+        for k, v in self.saved_env.items():
+            if v is None:
+                os.environ.pop(k)
+            else:
+                os.environ[k] = v
+
+    def test_get_credentials(self):
+        creds = get_credentials()  # botocore should discover these from os.environ
+        self.assertEqual(creds['aws_access_key'], 'test-AWS_ACCESS_KEY_ID')
+        self.assertEqual(creds['aws_secret_access_key'], 'test-AWS_SECRET_ACCESS_KEY')
+        self.assertEqual(creds['aws_token'], 'test-AWS_SESSION_TOKEN')
+
+    def test_boto_class(self):
+        auth = BotoAWSRequestsAuth(aws_host='search-foo.us-east-1.es.amazonaws.com',
+                                   aws_region='us-east-1',
+                                   aws_service='es')
+        mock_request = mock.Mock()
+        mock_request.url = 'search-foo.us-east-1.es.amazonaws.com'
+        mock_request.method = 'GET'
+        mock_request.body = None
+        mock_request.headers = {}
+        auth(mock_request)  # dummy call to __call__ method
+        self.assertEqual(auth.aws_access_key, 'test-AWS_ACCESS_KEY_ID')
+        self.assertEqual(auth.aws_secret_access_key, 'test-AWS_SECRET_ACCESS_KEY')
+        self.assertEqual(auth.aws_token, 'test-AWS_SESSION_TOKEN')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mock==1.3.0
 requests==2.9.1
+botocore==1.7.8


### PR DESCRIPTION
The existing recommendations for using Boto to gather credentials from the environment are great, however, they fall short when instantiating arguments to the `Elasticsearch` class long before a request is made (e.g., in a Django settings file per http://docs.wagtail.io/en/v1.12.1/topics/search/backends.html#amazon-aws-elasticsearch), because temporary credentials provided via instance metadata will expire from time to time.

This PR adds a new class, `BotoAWSRequestsAuth`, that handles gathering credentials via Boto automatically at runtime. This allows us to rely on Boto's underlying credential expiry controls.

This also includes two minor enhancements to the existing API:
- Switch to `botocore` which contains all the functionality we need, but fewer dependencies
- Use `get_frozen_credentials()` to avoid the race condition where one or more properties may be refreshed and the other(s) not refreshed