### PR TITLE
Allow to sign additional headers in request

### DIFF
--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -45,7 +45,8 @@ class AWSRequestsAuth(requests.auth.AuthBase):
                  aws_host,
                  aws_region,
                  aws_service,
-                 aws_token=None):
+                 aws_token=None,
+                 misc_sign_headers=None):
         """
         Example usage for talking to an AWS Elasticsearch Service:
 
@@ -65,6 +66,7 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         self.aws_region = aws_region
         self.service = aws_service
         self.aws_token = aws_token
+        self.misc_sign_headers = misc_sign_headers
 
     def __call__(self, r):
         """
@@ -88,9 +90,10 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         return self.get_aws_request_headers(r=r,
                                             aws_access_key=self.aws_access_key,
                                             aws_secret_access_key=self.aws_secret_access_key,
-                                            aws_token=self.aws_token)
+                                            aws_token=self.aws_token,
+                                            misc_sign_headers=self.misc_sign_headers)
 
-    def get_aws_request_headers(self, r, aws_access_key, aws_secret_access_key, aws_token):
+    def get_aws_request_headers(self, r, aws_access_key, aws_secret_access_key, aws_token, misc_sign_headers):
         """
         Returns a dictionary containing the necessary headers for Amazon's
         signature version 4 signing process. An example return value might
@@ -128,6 +131,10 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         signed_headers = 'host;x-amz-date'
         if aws_token:
             signed_headers += ';x-amz-security-token'
+
+        # Sign additional headers in request
+        if misc_sign_headers:
+            signed_headers += ";" + ";".join(misc_sign_headers)
 
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').

--- a/aws_requests_auth/boto_utils.py
+++ b/aws_requests_auth/boto_utils.py
@@ -31,7 +31,7 @@ def get_credentials(credentials_obj=None):
 
 class BotoAWSRequestsAuth(AWSRequestsAuth):
 
-    def __init__(self, aws_host, aws_region, aws_service):
+    def __init__(self, aws_host, aws_region, aws_service, misc_sign_headers=None):
         """
         Example usage for talking to an AWS Elasticsearch Service:
 
@@ -43,11 +43,13 @@ class BotoAWSRequestsAuth(AWSRequestsAuth):
         automatically from the environment, in the order described here:
         http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
         """
-        super(BotoAWSRequestsAuth, self).__init__(None, None, aws_host, aws_region, aws_service)
+        super(BotoAWSRequestsAuth, self).__init__(None, None, aws_host, aws_region, aws_service, misc_sign_headers=misc_sign_headers)
+        self._misc_sign_headers = misc_sign_headers
         self._refreshable_credentials = Session().get_credentials()
 
     def get_aws_request_headers_handler(self, r):
         # provide credentials explicitly during each __call__, to take advantage
         # of botocore's underlying logic to refresh expired credentials
         credentials = get_credentials(self._refreshable_credentials)
+        credentials['misc_sign_headers'] = self._misc_sign_headers
         return self.get_aws_request_headers(r, **credentials)

--- a/aws_requests_auth/tests/test_boto_utils.py
+++ b/aws_requests_auth/tests/test_boto_utils.py
@@ -58,3 +58,36 @@ class TestBotoUtils(unittest.TestCase):
             'x-amz-content-sha256': hashlib.sha256(b'').hexdigest(),
 
         }, mock_request.headers)
+
+    def test_boto_class_misc_headers(self):
+        boto_auth_inst = BotoAWSRequestsAuth(
+            aws_host='search-foo.us-east-1.es.amazonaws.com',
+            aws_region='us-east-1',
+            aws_service='es',
+            misc_sign_headers=['x-misc-header']
+        )
+        url = 'http://search-foo.us-east-1.es.amazonaws.com:80/'
+        mock_request = mock.Mock()
+        mock_request.url = url
+        mock_request.method = "GET"
+        mock_request.body = None
+        mock_request.headers = {
+            "x-misc-header": "misc-header"
+        }
+
+        self.maxDiff = None
+
+        frozen_datetime = datetime.datetime(2016, 6, 18, 22, 4, 5)
+        with mock.patch('datetime.datetime') as mock_datetime:
+            mock_datetime.utcnow.return_value = frozen_datetime
+            boto_auth_inst(mock_request)
+        self.assertEqual({
+            'x-misc-header': 'misc-header',
+            'Authorization': 'AWS4-HMAC-SHA256 Credential=test-AWS_ACCESS_KEY_ID/20160618/us-east-1/es/aws4_request, '
+                             'SignedHeaders=host;x-amz-date;x-amz-security-token;x-misc-header, '
+                             'Signature=66d9ac050292403b134a1d5095007f1be57d2879910dbb66e43d447d91fd0842',
+            'x-amz-date': '20160618T220405Z',
+            'X-Amz-Security-Token': 'test-AWS_SESSION_TOKEN',
+            'x-amz-content-sha256': hashlib.sha256(b'').hexdigest(),
+
+        }, mock_request.headers)


### PR DESCRIPTION
This change will allow you to sign additional headers in request

Linked issue https://github.com/DavidMuller/aws-requests-auth/issues/38