### PR TITLE
Add ability to pass parameters to the botocore session.

### DIFF
--- a/aws_requests_auth/boto_utils.py
+++ b/aws_requests_auth/boto_utils.py
@@ -31,7 +31,7 @@ def get_credentials(credentials_obj=None):
 
 class BotoAWSRequestsAuth(AWSRequestsAuth):
 
-    def __init__(self, aws_host, aws_region, aws_service, session_params={}):
+    def __init__(self, aws_host, aws_region, aws_service, profile=None):
         """
         Example usage for talking to an AWS Elasticsearch Service:
 
@@ -44,7 +44,7 @@ class BotoAWSRequestsAuth(AWSRequestsAuth):
         http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
         """
         super(BotoAWSRequestsAuth, self).__init__(None, None, aws_host, aws_region, aws_service)
-        self._refreshable_credentials = Session(**session_params).get_credentials()
+        self._refreshable_credentials = Session(profile=profile).get_credentials()
 
     def get_aws_request_headers_handler(self, r):
         # provide credentials explicitly during each __call__, to take advantage

--- a/aws_requests_auth/boto_utils.py
+++ b/aws_requests_auth/boto_utils.py
@@ -31,7 +31,7 @@ def get_credentials(credentials_obj=None):
 
 class BotoAWSRequestsAuth(AWSRequestsAuth):
 
-    def __init__(self, aws_host, aws_region, aws_service):
+    def __init__(self, aws_host, aws_region, aws_service, session_params={}):
         """
         Example usage for talking to an AWS Elasticsearch Service:
 
@@ -44,7 +44,7 @@ class BotoAWSRequestsAuth(AWSRequestsAuth):
         http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
         """
         super(BotoAWSRequestsAuth, self).__init__(None, None, aws_host, aws_region, aws_service)
-        self._refreshable_credentials = Session().get_credentials()
+        self._refreshable_credentials = Session(**session_params).get_credentials()
 
     def get_aws_request_headers_handler(self, r):
         # provide credentials explicitly during each __call__, to take advantage


### PR DESCRIPTION
Adds `session_params` parameter to `BotoAwsRequestsAuth` that gets unpacked into the botocore session object. This allows things like passing in regions, profiles, etc... that are outside the default way botocore picks credentials. Solves #51 