### PR TITLE
Basic wheel building support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 MANIFEST
 dist/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
   
 # command to install dependencies
-install: pip install -r requirements.txt
+install: pip install -r dev-requirements.txt
 
 # command to run tests
 script: python -m unittest discover aws_requests_auth

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
+  - "3.7"
+  - "3.8"
   
 # command to install dependencies
 install: pip install -r dev-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 mock==1.3.0
-wheel==0.34.2
+wheel

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+mock==1.3.0
+wheel==0.34.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-mock==1.3.0
 requests==2.20.0
 botocore==1.7.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(
@@ -10,7 +10,10 @@ setup(
     url='https://github.com/davidmuller/aws-requests-auth',
     description='AWS signature version 4 signing process for the python requests module',
     long_description='See https://github.com/davidmuller/aws-requests-auth for installation and usage instructions.',
-    install_requires=['requests>=0.14.0'],
+    install_requires=[
+        'botocore>=1.7.8',
+        'requests>=2.20.0',
+    ],
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',


### PR DESCRIPTION
These are the code changes mentioned in #54, as well as fixing the dependency list in `setup.py` to match `requirements.txt`.

With this, a wheel can be built like so:
```
$ python3 -m venv .venv
$ .venv/bin/pip install -r dev-requirements.txt
$ .venv/bin/python setup.py sdist bdist_wheel
```