### PR TITLE
Prep for wheel support on pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info
 MANIFEST
 dist/
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog (aws-requests-auth)
 ==================
 
+0.4.3
+------------------
+- Also publish the package as a wheel
+    - Contributed by @kgaughan: https://github.com/DavidMuller/aws-requests-auth/issues/54
+
 0.4.2
 ------------------
 - Add x-amz-content-sha256 header to request

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(


### PR DESCRIPTION
## What

This PR preps the repository for publishing a wheel as per @kgaughan 's recommendations in:

- `Request: release aws-requests-auth as a wheel` - https://github.com/DavidMuller/aws-requests-auth/issues/54
- `Basic wheel building support` - https://github.com/DavidMuller/aws-requests-auth/pull/55