### PR TITLE
Update Python 3 versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   
 # command to install dependencies
 install: pip install -r requirements.txt


### PR DESCRIPTION
- Removes Python 3.4 as no longer supported
- Python 3.5, 3.6, 3.7, and 3.8 are the currently supported releases