### PR TITLE
Fix “object supporting the buffer API required” for multipart requests

### DIFF
--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -129,6 +129,10 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         if aws_token:
             signed_headers += ';x-amz-security-token'
 
+        # Materialize body if it is a generator (e.g. toolbelt's MultipartEncoder instance)
+        if r.body and hasattr(r.body, 'to_string'):
+            r.body = r.body.to_string()
+
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').
         body = r.body if r.body else bytes()

--- a/aws_requests_auth/tests/test_aws_auth.py
+++ b/aws_requests_auth/tests/test_aws_auth.py
@@ -5,6 +5,7 @@ import sys
 import unittest
 
 from aws_requests_auth.aws_auth import AWSRequestsAuth
+from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 
 class TestAWSRequestsAuth(unittest.TestCase):
@@ -150,6 +151,35 @@ class TestAWSRequestsAuth(unittest.TestCase):
             'Content-Type': 'application/x-www-form-urlencoded',
             'x-amz-date': '20160618T220405Z',
             'x-amz-content-sha256': hashlib.sha256(mock_request.body.encode()).hexdigest(),
+
+        }, mock_request.headers)
+
+    def test_auth_for_post_with_multipart_body(self):
+        auth = AWSRequestsAuth(aws_access_key='YOURKEY',
+                               aws_secret_access_key='YOURSECRET',
+                               aws_host='search-foo.us-east-1.es.amazonaws.com',
+                               aws_region='us-east-1',
+                               aws_service='es')
+        url = 'http://search-foo.us-east-1.es.amazonaws.com:80/'
+        mock_request = mock.Mock()
+        mock_request.url = url
+        mock_request.method = "POST"
+        mock_request.body = MultipartEncoder(fields={'foo': 'bar'}, boundary='test')
+        mock_request.headers = {
+            'Content-Type': 'multipart/form-data; boundary=test',
+        }
+
+        frozen_datetime = datetime.datetime(2016, 6, 18, 22, 4, 5)
+        with mock.patch('datetime.datetime') as mock_datetime:
+            mock_datetime.utcnow.return_value = frozen_datetime
+            auth(mock_request)
+        self.assertEqual({
+            'Authorization': 'AWS4-HMAC-SHA256 Credential=YOURKEY/20160618/us-east-1/es/aws4_request, '
+                             'SignedHeaders=host;x-amz-date, '
+                             'Signature=3a49a96a093e8ae5a9c59827117741d1627d8462eac7542220dabc317e92b1f7',
+            'Content-Type': 'multipart/form-data; boundary=test',
+            'x-amz-date': '20160618T220405Z',
+            'x-amz-content-sha256': hashlib.sha256(mock_request.body).hexdigest(),
 
         }, mock_request.headers)
 


### PR DESCRIPTION
This fixes https://github.com/aidan-/httpie-aws-authv4/issues/10 (see this original issue for more details)

**The problem**

Sometimes body can be not only string, but some complex objects-generators like [`request_toolbelt`'s `MultipartEncoder`](https://toolbelt.readthedocs.io/en/latest/uploading-data.html).

In that case following error will be thrown:
```
TypeError: object supporting the buffer API required
```
when trying to calculate body hash here: https://github.com/DavidMuller/aws-requests-auth/blob/b86907f11a18cb5d0d3f048dd3e8d2eaf69a2ec3/aws_requests_auth/aws_auth.py#L146

where `body` is `<MultipartEncoder: <generator object MultiValueOrderedDict.items at **0x7f7e9c69c970>>`

How to test yourself:
```sh
pip install httpie httpie-aws-authv4
http --auth-type aws4 --auth REDACTED.execute-api.us-west-2.amazonaws.com \
     --multipart POST http://example.com/test field=value
```

**Implementation notes**

In case of `MultipartEncoder`, I had to materialize request body to string **and replace request body with it**, otherwise HTTPie would hang up undefinitely. I'm not good at Python, but suppose it is because we had emptied generator object for hash calculation and HTTPie waits for data from it to send in body but data would never come again.

