### PR TITLE
Add botocore to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ setup(
     url='https://github.com/davidmuller/aws-requests-auth',
     description='AWS signature version 4 signing process for the python requests module',
     long_description='See https://github.com/davidmuller/aws-requests-auth for installation and usage instructions.',
-    install_requires=['requests>=0.14.0'],
+    install_requires=[
+        'botocore<2.0',
+        'requests>=0.14.0',
+    ],
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',


### PR DESCRIPTION
### Motivation
We have a client library for our GraphQL API built on top of AWS AppSync. We use aws-requests-auth to sign off requests to AppSync. The library itself is no more than an API client, so the environment we run it in doesn't have botocore or boto3 installed. But currently, we had to add botocore to dependencies of our client library, because although aws-requests-auth depends on botocore, it doesn't install it as a dependency.

I believe botocore should be on the list of dependencies for aws-requests-auth.
