### PR TITLE
Fix 'object supporting the buffer API required' for Reader requests

### DIFF
--- a/aws_requests_auth/aws_auth.py
+++ b/aws_requests_auth/aws_auth.py
@@ -1,6 +1,7 @@
 import hmac
 import hashlib
 import datetime
+from io import BufferedIOBase
 
 try:
     # python 2
@@ -128,6 +129,10 @@ class AWSRequestsAuth(requests.auth.AuthBase):
         signed_headers = 'host;x-amz-date'
         if aws_token:
             signed_headers += ';x-amz-security-token'
+
+        # Materialize body if it is a Reader/BufferedReader
+        if isinstance(r.body, BufferedIOBase):
+            r.body = r.body.read()
 
         # Create payload hash (hash of the request body content). For GET
         # requests, the payload is an empty string ('').


### PR DESCRIPTION
Fix for `httpie`, which uses "aws-requests-auth", cf. https://github.com/aidan-/httpie-aws-authv4/issues/15
"TypeError: object supporting the buffer API required with BufferedReader requests"

Related to https://github.com/DavidMuller/aws-requests-auth/pull/60, similar problem. The two fixes should be compatible and should _both_ be applied, please.
